### PR TITLE
Expose Client class and types in weather package __init__.py

### DIFF
--- a/src/frequenz/client/weather/__init__.py
+++ b/src/frequenz/client/weather/__init__.py
@@ -2,3 +2,8 @@
 # Copyright © 2025 Frequenz Energy-as-a-Service GmbH
 
 """Weather API Client for Python."""
+
+from ._client import Client
+from ._types import ForecastFeature, Forecasts, Location
+
+__all__ = ["Client", "ForecastFeature", "Forecasts", "Location"]


### PR DESCRIPTION
Updates the __init__.py to properly export the Client class and types
from the weather client package.

Before: `from frequenz.client.weather._client import Client`
After:` from frequenz.client.weather import Client`

This matches the usage documented in the README.md.