### PR TITLE
Broaden numpy dependency version range to allow v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.12.2, < 5",
-  "numpy >= 2.0, < 3",
+  "numpy >= 1.26.4, < 3",
   "frequenz-api-common >= 0.6.0, < 0.7.0",
   "googleapis-common-protos >= 1.56.4, < 2",
   "frequenz-channels >= 1.6.1, < 2",


### PR DESCRIPTION
Supports using the client in projects which haven't migrated yet.