### PR TITLE
Require timezone-aware timestamps in ndarray methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-* Require datetime objects to be timezone-aware in upsampling function.
+* Require datetime objects to be timezone-aware in upsampling and ndarray method.
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 
 ## Upgrading
 
+* Require datetime objects to be timezone-aware in upsampling function.
+
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features

--- a/src/frequenz/client/weather/_types.py
+++ b/src/frequenz/client/weather/_types.py
@@ -246,7 +246,7 @@ class Forecasts:
         If any of the filters are None, all values for that parameter will be returned.
 
         Args:
-            validity_times: The validity times to filter by.
+            validity_times: The validity times to filter by (tz-aware).
             locations: The locations to filter by.
             features: The features to filter by.
 
@@ -292,12 +292,19 @@ class Forecasts:
 
             # get the val indexes of the proto for the filtered validity times
             if validity_times:
+                # We require tz-aware datetime objects to avoid ambiguity
+                if any(
+                    t.tzinfo is None or t.utcoffset() is None for t in validity_times
+                ):
+                    raise ValueError("All validity_times must be timezone-aware")
                 for req_validitiy_time in validity_times:
                     found = False
                     for t_index, val_time in enumerate(
                         self._forecasts_pb.location_forecasts[0].forecasts
                     ):
-                        if req_validitiy_time == val_time.valid_at_ts.ToDatetime():
+                        if req_validitiy_time == val_time.valid_at_ts.ToDatetime(
+                            dt.UTC
+                        ):
                             validity_times_indexes.append(t_index)
                             found = True
                             break

--- a/src/frequenz/client/weather/_types.py
+++ b/src/frequenz/client/weather/_types.py
@@ -396,8 +396,8 @@ class Forecasts:
 
         Args:
             array: 3D array from to_ndarray_vlf (time, location, feature)
-            validity_times: List of original timestamps
-            target_times: List of desired timestamps to interpolate to
+            validity_times: List of original timestamps (tz-aware)
+            target_times: List of desired timestamps to interpolate to (tz-aware)
             features: List of forecast features
             solar_offset_sec: Time offset in seconds to shift solar forecasts
 
@@ -422,6 +422,13 @@ class Forecasts:
         # Validate target timestamps are strictly increasing
         if not all(t1 < t2 for t1, t2 in zip(target_times[:-1], target_times[1:])):
             raise ValueError("target_times must be strictly increasing")
+
+        # We require tz-aware datetime objects to avoid ambiguity,
+        # since for naive timestamps local time is assumed.
+        if any(t.tzinfo is None or t.utcoffset() is None for t in target_times):
+            raise ValueError("All target_times must be timezone-aware")
+        if any(t.tzinfo is None or t.utcoffset() is None for t in validity_times):
+            raise ValueError("All validity_times must be timezone-aware")
 
         vts = np.array([t.timestamp() for t in validity_times])
         tts = np.array([t.timestamp() for t in target_times])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -108,9 +108,9 @@ def forecastdata() -> (  # pylint: disable=too-many-locals
         LocationProto(latitude=43.0, longitude=19.0, country_code="CA"),
     ]
     valid_times = [
-        datetime.fromisoformat("2024-01-01T01:00:00"),
-        datetime.fromisoformat("2024-01-01T02:00:00"),
-        datetime.fromisoformat("2024-01-01T03:00:00"),
+        datetime.fromisoformat("2024-01-01T01:00:00Z"),
+        datetime.fromisoformat("2024-01-01T02:00:00Z"),
+        datetime.fromisoformat("2024-01-01T03:00:00Z"),
     ]
     feature_list = [
         weather_pb2.ForecastFeature.FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE,
@@ -188,18 +188,18 @@ class TestForecasts:
 
     """
 
-    valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
-    valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
-    valid_ts3 = datetime.fromisoformat("2024-01-01T03:00:00")
-    invalid_ts = datetime.fromisoformat("2024-01-02T03:00:00")
+    valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00Z")
+    valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00Z")
+    valid_ts3 = datetime.fromisoformat("2024-01-01T03:00:00Z")
+    invalid_ts = datetime.fromisoformat("2024-01-02T03:00:00Z")
 
     @pytest.fixture
     def sample_times(self) -> List[datetime]:
         """Fixture providing sample validity times."""
         return [
-            datetime.fromisoformat("2024-01-01T01:00:00"),
-            datetime.fromisoformat("2024-01-01T02:00:00"),
-            datetime.fromisoformat("2024-01-01T03:00:00"),
+            datetime.fromisoformat("2024-01-01T01:00:00Z"),
+            datetime.fromisoformat("2024-01-01T02:00:00Z"),
+            datetime.fromisoformat("2024-01-01T03:00:00Z"),
         ]
 
     def test_from_pb(


### PR DESCRIPTION
Requires timezone-aware datetime objects when using `to_ndarray_vlf` and `to_resampled_ndarray`. 

Using timezone-naive datetime objects is discouraged, since it's ambiguous. Supporting naive timestamps has caused problems in downstream apps by the `timestamp()` method implicitly assuming local time instead of UTC.

Fixes https://github.com/frequenz-floss/frequenz-client-weather-python/issues/32