### PR TITLE
Require signed requests in weather client

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ from datetime import timedelta
 
 client = Client(
     service_address,
+    auth_key="<auth-key>",
+    sign_secret="<signing-secret>",
     channel_defaults=ChannelOptions(
         ssl=SslOptions(
             enabled=False,
@@ -114,11 +116,16 @@ async for forecast in stream:
 The package also provides a command line interface to get weather forecast data.
 Use `-h` to see the available options.
 
+The CLI also reads `WEATHER_API_URL`, `WEATHER_API_AUTH_KEY`, and
+`WEATHER_API_SIGN_SECRET` when the matching flags are omitted.
+
 ### Get historical weather forecast
 
 ```bash
 weather-cli \
     --url <service-address> \
+    --auth-key <auth-key> \
+    --sign-secret <signing-secret> \
     --location "40,15" \
     --feature U_WIND_COMPONENT_100_METRE \
     --start 2024-03-14 \
@@ -131,8 +138,9 @@ weather-cli \
 ```bash
 weather-cli \
     --url <service-address> \
+    --auth-key <auth-key> \
+    --sign-secret <signing-secret> \
     --location "40, 15" \
     --feature TEMPERATURE_2_METRE \
     --mode live
 ```
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,3 +9,7 @@ API auth key and signing secret, and `weather-cli` accepts them via
 
 This release relaxes the API common dependency so it can work up to v1.0.0, as
 all v0.x versions should be compatible from v0.8.0 on.
+
+Runtime dependency lower bounds were updated to the current gRPC client stack,
+including `frequenz-client-base`, `frequenz-api-common`, `grpcio`, and
+`protobuf`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,10 @@
 
 ## Summary
 
-This release relaxes the API common dependency so it can work up to v1.0.0, as all v0.x versions should be compatible from v0.8.0 on.
+This release requires signed Weather API requests. The client now requires an
+API auth key and signing secret, and `weather-cli` accepts them via
+`--auth-key` / `--sign-secret` or `WEATHER_API_AUTH_KEY` /
+`WEATHER_API_SIGN_SECRET`.
+
+This release relaxes the API common dependency so it can work up to v1.0.0, as
+all v0.x versions should be compatible from v0.8.0 on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,15 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "typing-extensions >= 4.12.2, < 5",
+  "typing-extensions >= 4.13.0, < 5",
   "numpy >= 1.26.4, < 3",
-  "frequenz-api-common >= 0.8.0, < 1",
+  "frequenz-api-common >= 0.8.10, < 1",
   "googleapis-common-protos >= 1.70.0, < 2",
-  "frequenz-channels >= 1.6.1, < 2",
-  "frequenz-client-base >= 0.11.0, < 0.12",
+  "frequenz-channels >= 1.8.0, < 2",
+  "frequenz-client-base >= 0.11.2, < 0.12",
   "frequenz-api-weather >= 0.14.0, < 0.15.0",
+  "grpcio >= 1.81.0, < 2",
+  "protobuf >= 6.33.6, < 8",
 ]
 dynamic = ["version"]
 

--- a/src/frequenz/client/weather/_client.py
+++ b/src/frequenz/client/weather/_client.py
@@ -23,10 +23,12 @@ from ._types import ForecastFeature, Forecasts, Location
 class Client(BaseApiClient[weather_pb2_grpc.WeatherForecastServiceStub]):
     """Weather forecast client."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         server_url: str,
         *,
+        auth_key: str,
+        sign_secret: str,
         connect: bool = True,
         channel_defaults: ChannelOptions = ChannelOptions(),
     ) -> None:
@@ -34,6 +36,8 @@ class Client(BaseApiClient[weather_pb2_grpc.WeatherForecastServiceStub]):
 
         Args:
             server_url: The URL of the server to connect to.
+            auth_key: The API key to use when connecting to the service.
+            sign_secret: The secret to use when signing requests.
             connect: Whether to connect to the server as soon as a client instance is
                 created. If `False`, the client will not connect to the server until
                 [connect()][frequenz.client.base.client.BaseApiClient.connect] is
@@ -45,6 +49,8 @@ class Client(BaseApiClient[weather_pb2_grpc.WeatherForecastServiceStub]):
             weather_pb2_grpc.WeatherForecastServiceStub,
             connect=connect,
             channel_defaults=channel_defaults,
+            auth_key=auth_key,
+            sign_secret=sign_secret,
         )
         self._streams: dict[
             tuple[Location | ForecastFeature, ...],

--- a/src/frequenz/client/weather/cli/__main__.py
+++ b/src/frequenz/client/weather/cli/__main__.py
@@ -5,6 +5,7 @@
 
 import argparse
 import asyncio
+import os
 from datetime import datetime, timedelta
 
 from frequenz.client.base.channel import ChannelOptions, KeepAliveOptions, SslOptions
@@ -19,7 +20,20 @@ def main() -> None:
     parser.add_argument(
         "--url",
         type=str,
+        default=os.environ.get("WEATHER_API_URL"),
         help="URL of the Weather service",
+    )
+    parser.add_argument(
+        "--auth-key",
+        type=str,
+        default=os.environ.get("WEATHER_API_AUTH_KEY"),
+        help="API auth key for authentication",
+    )
+    parser.add_argument(
+        "--sign-secret",
+        type=str,
+        default=os.environ.get("WEATHER_API_SIGN_SECRET"),
+        help="API signing secret for authentication",
     )
     parser.add_argument(
         "--mode",
@@ -56,6 +70,13 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    if args.url is None:
+        parser.error("--url or WEATHER_API_URL is required")
+    if args.auth_key is None:
+        parser.error("--auth-key or WEATHER_API_AUTH_KEY is required")
+    if args.sign_secret is None:
+        parser.error("--sign-secret or WEATHER_API_SIGN_SECRET is required")
+
     # Validate arguments based on mode
     if args.mode == "historical":
         if args.start is None or args.end is None:
@@ -68,6 +89,8 @@ def main() -> None:
         asyncio.run(
             run(
                 service_address=args.url,
+                auth_key=args.auth_key,
+                sign_secret=args.sign_secret,
                 location=args.location,
                 feature_names=args.feature,
                 start=args.start,
@@ -79,9 +102,11 @@ def main() -> None:
         print("\nReceived interrupt, shutting down...")
 
 
-async def run(  # pylint: disable=too-many-arguments
+async def run(  # pylint: disable=too-many-arguments,too-many-locals
     *,
     service_address: str,
+    auth_key: str,
+    sign_secret: str,
     location: tuple[float, float],
     feature_names: list[str],
     start: datetime | None,
@@ -92,6 +117,8 @@ async def run(  # pylint: disable=too-many-arguments
 
     Args:
         service_address: service address
+        auth_key: API auth key
+        sign_secret: API signing secret
         location: location in lat, lon format
         feature_names: feature names
         start: start datetime (historical mode only)
@@ -100,6 +127,8 @@ async def run(  # pylint: disable=too-many-arguments
     """
     client = Client(
         service_address,
+        auth_key=auth_key,
+        sign_secret=sign_secret,
         channel_defaults=ChannelOptions(
             ssl=SslOptions(enabled=False),
             keep_alive=KeepAliveOptions(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,112 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Test the weather CLI."""
+
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+from frequenz.client.weather.cli import __main__ as cli
+
+
+def test_main_requires_auth_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that the CLI requires an auth key."""
+    monkeypatch.delenv("WEATHER_API_AUTH_KEY", raising=False)
+    monkeypatch.delenv("WEATHER_API_SIGN_SECRET", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "weather-cli",
+            "--url",
+            "grpc://weather.example.com:443",
+            "--sign-secret",
+            "test-sign-secret",
+            "--mode",
+            "live",
+            "--feature",
+            "TEMPERATURE_2_METRE",
+            "--location",
+            "40,15",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        cli.main()
+
+    assert error.value.code == 2
+
+
+def test_main_requires_sign_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that the CLI requires a signing secret."""
+    monkeypatch.delenv("WEATHER_API_AUTH_KEY", raising=False)
+    monkeypatch.delenv("WEATHER_API_SIGN_SECRET", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "weather-cli",
+            "--url",
+            "grpc://weather.example.com:443",
+            "--auth-key",
+            "test-auth-key",
+            "--mode",
+            "live",
+            "--feature",
+            "TEMPERATURE_2_METRE",
+            "--location",
+            "40,15",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        cli.main()
+
+    assert error.value.code == 2
+
+
+def test_main_uses_environment_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that the CLI reads URL and auth credentials from the environment."""
+    calls: list[dict[str, object]] = []
+
+    async def fake_run(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setenv("WEATHER_API_URL", "grpc://weather.example.com:443")
+    monkeypatch.setenv("WEATHER_API_AUTH_KEY", "test-auth-key")
+    monkeypatch.setenv("WEATHER_API_SIGN_SECRET", "test-sign-secret")
+    monkeypatch.setattr(cli, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "weather-cli",
+            "--mode",
+            "historical",
+            "--feature",
+            "TEMPERATURE_2_METRE",
+            "--location",
+            "40,15",
+            "--start",
+            "2024-03-14T00:00:00+00:00",
+            "--end",
+            "2024-03-15T00:00:00+00:00",
+        ],
+    )
+
+    cli.main()
+
+    assert calls == [
+        {
+            "service_address": "grpc://weather.example.com:443",
+            "auth_key": "test-auth-key",
+            "sign_secret": "test-sign-secret",
+            "location": (40.0, 15.0),
+            "feature_names": ["TEMPERATURE_2_METRE"],
+            "start": datetime(2024, 3, 14, tzinfo=timezone.utc),
+            "end": datetime(2024, 3, 15, tzinfo=timezone.utc),
+            "mode": "historical",
+        }
+    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,12 +28,37 @@ class TestClient:
     @fixture
     def client(self, mock_stub: AsyncMock) -> Client:
         """Create a client with a mock stub."""
-        client = Client("test-server", connect=False)
+        client = Client(
+            "test-server",
+            auth_key="test-auth-key",
+            sign_secret="test-sign-secret",
+            connect=False,
+        )
         # pylint: disable=protected-access
         client._stub = mock_stub
         client._channel = MagicMock()
         # pylint: enable=protected-access
         return client
+
+    def test_init_requires_auth_key(self) -> None:
+        """Test that the client requires an auth key."""
+        with pytest.raises(TypeError, match="auth_key"):
+            # pylint: disable-next=missing-kwoa
+            Client(  # type: ignore[call-arg]
+                "test-server",
+                sign_secret="test-sign-secret",
+                connect=False,
+            )
+
+    def test_init_requires_sign_secret(self) -> None:
+        """Test that the client requires a signing secret."""
+        with pytest.raises(TypeError, match="sign_secret"):
+            # pylint: disable-next=missing-kwoa
+            Client(  # type: ignore[call-arg]
+                "test-server",
+                auth_key="test-auth-key",
+                connect=False,
+            )
 
     @fixture
     def sample_historical_response(


### PR DESCRIPTION
Implement the weather service requirement for signed requests on all RPCs.

- **Client**: `Client.__init__` now requires keyword-only `auth_key` and `sign_secret`, passed to `BaseApiClient` for HMAC signing.
- **CLI**: `weather-cli` accepts `--auth-key`, `--sign-secret`, with env fallbacks `WEATHER_API_URL`, `WEATHER_API_AUTH_KEY`, `WEATHER_API_SIGN_SECRET`. Missing credentials produce a clear error.
- **Deps**: Runtime bounds bumped to the current gRPC stack: `frequenz-client-base >= 0.11.2`, `frequenz-api-common >= 0.8.10`, `grpcio >= 1.81.0`, `protobuf >= 6.33.6`.
- **Docs**: README examples updated; RELEASE_NOTES.md updated.
- **Tests**: Existing tests updated to supply credentials; added focused constructor and CLI tests for missing credentials and env fallbacks.
